### PR TITLE
fix(docs): Update for gulp@4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ gulp.task('md', function() {
     .pipe(gulp.dest('dist'));
 });
 
-gulp.task('default', ['md']);
+gulp.task('default', gulp.series(['md']));
 ```
 
 **Extended Example**
@@ -61,7 +61,7 @@ gulp.task('md', function() {
     .pipe(gulp.dest('dist'));
 });
 
-gulp.task('default', ['md']);
+gulp.task('default', gulp.series(['md']));
 ```
 
 **Using Plugins**


### PR DESCRIPTION
The example code doesn't work in gulp@4. This change works if the default supported version of gulp should be v4.